### PR TITLE
feat: 재가공 이슈의 상세 페이지 API 구현

### DIFF
--- a/src/main/java/com/neupinion/neupinion/issue/application/ReprocessedIssueService.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/ReprocessedIssueService.java
@@ -2,10 +2,16 @@ package com.neupinion.neupinion.issue.application;
 
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueCreateRequest;
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueResponse;
+import com.neupinion.neupinion.issue.application.dto.ShortReprocessedIssueResponse;
 import com.neupinion.neupinion.issue.domain.Category;
 import com.neupinion.neupinion.issue.domain.ReprocessedIssue;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueTag;
+import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueParagraphRepository;
 import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueRepository;
+import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueTagRepository;
 import com.neupinion.neupinion.issue.domain.repository.dto.ReprocessedIssueWithCommentCount;
+import com.neupinion.neupinion.issue.exception.ReprocessedIssueException.ReprocessedIssueNotFoundException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -24,21 +30,38 @@ public class ReprocessedIssueService {
     private static final int REPROCESSED_ISSUES_SIZE = 4;
 
     private final ReprocessedIssueRepository reprocessedIssueRepository;
+    private final ReprocessedIssueParagraphRepository reprocessedIssueParagraphRepository;
+    private final ReprocessedIssueTagRepository reprocessedIssueTagRepository;
 
     @Transactional
     public Long createReprocessedIssue(final ReprocessedIssueCreateRequest request) {
         final ReprocessedIssue reprocessedIssue = ReprocessedIssue.forSave(request.getTitle(),
                                                                            request.getImageUrl(),
+                                                                           request.getCaption(),
+                                                                            request.getOriginUrl(),
                                                                            Category.from(request.getCategory()));
+
         return reprocessedIssueRepository.save(reprocessedIssue).getId();
     }
 
-    public List<ReprocessedIssueResponse> findReprocessedIssues(final String dateFormat) {
+    public List<ShortReprocessedIssueResponse> findReprocessedIssues(final String dateFormat) {
         final LocalDate targetDate = LocalDate.parse(dateFormat, FORMATTER);
         final PageRequest pageRequest = PageRequest.of(0, REPROCESSED_ISSUES_SIZE, Sort.by("createdAt").descending());
         final List<ReprocessedIssueWithCommentCount> issuesWithCommentCount = reprocessedIssueRepository.findByCreatedAt(
             targetDate, pageRequest);
 
-        return ReprocessedIssueResponse.of(issuesWithCommentCount);
+        return ShortReprocessedIssueResponse.of(issuesWithCommentCount);
+    }
+
+    public ReprocessedIssueResponse findReprocessedIssue(final Long id) {
+        final ReprocessedIssue reprocessedIssue = reprocessedIssueRepository.findById(id)
+            .orElseThrow(ReprocessedIssueNotFoundException::new);
+        final List<ReprocessedIssueParagraph> paragraphs = reprocessedIssueParagraphRepository.findByReprocessedIssueIdOrderById(
+            id);
+        final List<String> tags = reprocessedIssueTagRepository.findByReprocessedIssueId(id).stream()
+            .map(ReprocessedIssueTag::getTag)
+            .toList();
+
+        return ReprocessedIssueResponse.of(reprocessedIssue, paragraphs, tags);
     }
 }

--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueCreateRequest.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueCreateRequest.java
@@ -19,11 +19,19 @@ public class ReprocessedIssueCreateRequest {
     @NotBlank
     private final String imageUrl;
 
+    @Schema(description = "재가공 이슈 썸네일 이미지 캡션", example = "이미지 1")
+    private final String caption;
+
+    @Schema(description = "재가공 이슈 원문 URL", example = "https://origin.com?origin=1234")
+    @NotBlank
+    private final String originUrl;
+
     @Schema(description = "재가공 이슈 카테고리", example = "ECONOMY")
     @NotBlank
     private final String category;
 
-    public static ReprocessedIssueCreateRequest of(final String title, final String imageUrl, final String category) {
-        return new ReprocessedIssueCreateRequest(title, imageUrl, category);
+    public static ReprocessedIssueCreateRequest of(final String title, final String imageUrl, final String caption,
+                                                   final String originUrl, final String category) {
+        return new ReprocessedIssueCreateRequest(title, imageUrl, caption, originUrl, category);
     }
 }

--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueParagraphResponse.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueParagraphResponse.java
@@ -1,0 +1,26 @@
+package com.neupinion.neupinion.issue.application.dto;
+
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "재가공 이슈 단락 응답")
+public class ReprocessedIssueParagraphResponse {
+
+    @Schema(description = "재가공 이슈 단락 ID", example = "1")
+    private final Long id;
+
+    @Schema(description = "재가공 이슈 단락", example = "블룸버그통신 등에 따르면 22일(현지 시간) 오전 9시를 전후로 미 워싱턴DC에 있는 펜타곤으로 보이는 건물에서 검은 연기가 피어오르는 사진이 트위터를 통해 국내외로 빠르게 확산했다.")
+    private final String paragraph;
+
+    @Schema(description = "재가공 이슈 단락 선택 여부", example = "true")
+    private final boolean selected;
+
+    public static ReprocessedIssueParagraphResponse of(final ReprocessedIssueParagraph paragraph) {
+        return new ReprocessedIssueParagraphResponse(paragraph.getId(), paragraph.getContent(),
+                                                     paragraph.isSelectable());
+    }
+}

--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueResponse.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/ReprocessedIssueResponse.java
@@ -1,50 +1,62 @@
 package com.neupinion.neupinion.issue.application.dto;
 
-import com.neupinion.neupinion.issue.domain.repository.dto.ReprocessedIssueWithCommentCount;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssue;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@Schema(description = "재가공 이슈 응답")
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@AllArgsConstructor
+@Schema(description = "재가공 이슈 응답")
 public class ReprocessedIssueResponse {
 
-    @Schema(description = "재가공 이슈 id", example = "1")
+    @Schema(description = "재가공 이슈 ID", example = "1")
     private final Long id;
 
-    @Schema(description = "재가공 이슈 제목", example = "재가공 이슈 제목")
+    @Schema(description = "재가공 이슈 제목", example = "이슈 제목")
     private final String title;
 
-    @Schema(description = "재가공 이슈 썸네일 이미지", example = "https://image.com?image=1234")
+    @Schema(description = "이미지 URL", example = "https://neupinion.com/image/1")
     private final String imageUrl;
 
-    @Schema(description = "재가공 이슈 카테고리", example = "경제")
+    @Schema(description = "이미지 캡션", example = "이미지 1")
+    private final String caption;
+
+    @Schema(description = "카테고리", example = "SOCIAL")
     private final String category;
 
-    @Schema(description = "재가공 이슈의 조회수", example = "10")
-    private final int views;
-
-    @Schema(description = "공개된 포스트잇 개수", example = "10")
-    private final int opinionCount;
-
-    @Schema(description = "재가공 이슈 작성 날짜", example = "2024-01-08T11:44:30.327959")
+    @Schema(description = "발행일", example = "2024-02-28T11:44:30.327959")
     private final LocalDateTime createdAt;
 
-    public static List<ReprocessedIssueResponse> of(final List<ReprocessedIssueWithCommentCount> reprocessedIssues) {
-        return reprocessedIssues.stream()
-            .map(issue -> new ReprocessedIssueResponse(
-                issue.getReprocessedIssue().getId(),
-                issue.getReprocessedIssue().getTitle().getValue(),
-                issue.getReprocessedIssue().getImageUrl(),
-                issue.getReprocessedIssue().getCategory().getValue(),
-                issue.getReprocessedIssue().getViews(),
-                issue.getCommentCount().intValue(),
-                issue.getReprocessedIssue().getCreatedAt()
-            ))
+    @Schema(description = "원문 링크", example = "https://neupinion.com/origin/1")
+    private final String originUrl;
+
+    @Schema(description = "단락 리스트")
+    private final List<ReprocessedIssueParagraphResponse> content;
+
+    @Schema(description = "태그 리스트")
+    private final List<String> tags;
+
+    public static ReprocessedIssueResponse of(final ReprocessedIssue reprocessedIssue,
+                                              final List<ReprocessedIssueParagraph> paragraphs,
+                                              final List<String> tags) {
+        final List<ReprocessedIssueParagraphResponse> content = paragraphs.stream()
+            .map(ReprocessedIssueParagraphResponse::of)
             .toList();
+
+        return new ReprocessedIssueResponse(
+            reprocessedIssue.getId(),
+            reprocessedIssue.getTitle(),
+            reprocessedIssue.getImageUrl(),
+            reprocessedIssue.getCaption(),
+            reprocessedIssue.getCategory().name(),
+            reprocessedIssue.getCreatedAt(),
+            reprocessedIssue.getOriginUrl(),
+            content,
+            tags
+        );
     }
 }

--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/ShortReprocessedIssueResponse.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/ShortReprocessedIssueResponse.java
@@ -1,0 +1,50 @@
+package com.neupinion.neupinion.issue.application.dto;
+
+import com.neupinion.neupinion.issue.domain.repository.dto.ReprocessedIssueWithCommentCount;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "메인 홈의 재가공 이슈 응답")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ShortReprocessedIssueResponse {
+
+    @Schema(description = "재가공 이슈 id", example = "1")
+    private final Long id;
+
+    @Schema(description = "재가공 이슈 제목", example = "재가공 이슈 제목")
+    private final String title;
+
+    @Schema(description = "재가공 이슈 썸네일 이미지", example = "https://image.com?image=1234")
+    private final String imageUrl;
+
+    @Schema(description = "재가공 이슈 카테고리", example = "경제")
+    private final String category;
+
+    @Schema(description = "재가공 이슈의 조회수", example = "10")
+    private final int views;
+
+    @Schema(description = "공개된 포스트잇 개수", example = "10")
+    private final int opinionCount;
+
+    @Schema(description = "재가공 이슈 작성 날짜", example = "2024-01-08T11:44:30.327959")
+    private final LocalDateTime createdAt;
+
+    public static List<ShortReprocessedIssueResponse> of(final List<ReprocessedIssueWithCommentCount> reprocessedIssues) {
+        return reprocessedIssues.stream()
+            .map(issue -> new ShortReprocessedIssueResponse(
+                issue.getReprocessedIssue().getId(),
+                issue.getReprocessedIssue().getTitle(),
+                issue.getReprocessedIssue().getImageUrl(),
+                issue.getReprocessedIssue().getCategory().getValue(),
+                issue.getReprocessedIssue().getViews(),
+                issue.getCommentCount().intValue(),
+                issue.getReprocessedIssue().getCreatedAt()
+            ))
+            .toList();
+    }
+}

--- a/src/main/java/com/neupinion/neupinion/issue/domain/ReprocessedIssue.java
+++ b/src/main/java/com/neupinion/neupinion/issue/domain/ReprocessedIssue.java
@@ -38,6 +38,12 @@ public class ReprocessedIssue {
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
 
+    @Column(name = "caption")
+    private String caption;
+
+    @Column(name = "origin_url", nullable = false)
+    private String originUrl;
+
     @Column(name = "category", nullable = false)
     @Enumerated(EnumType.STRING)
     private Category category;
@@ -54,23 +60,27 @@ public class ReprocessedIssue {
     @Column(nullable = false)
     private LocalDateTime updatedAt = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MICROS);
 
-    private ReprocessedIssue(final Long id, final String title, final String imageUrl, final Category category,
-                             final int views, final Clock clock) {
+    private ReprocessedIssue(final Long id, final String title, final String imageUrl, final String caption,
+                             final String originUrl, final Category category, final int views, final Clock clock) {
         this.id = id;
         this.title = new IssueTitle(title);
         this.imageUrl = imageUrl;
+        this.caption = caption;
+        this.originUrl = originUrl;
         this.category = category;
         this.views = views;
         this.clock = clock;
     }
 
-    public static ReprocessedIssue forSave(final String title, final String imageUrl, final Category category,
-                                           final Clock clock) {
-        return new ReprocessedIssue(null, title, imageUrl, category, VIEWS_INITIALIZATION, clock);
+    public static ReprocessedIssue forSave(final String title, final String imageUrl, final String caption,
+                                           final String originUrl, final Category category, final Clock clock) {
+        return new ReprocessedIssue(null, title, imageUrl, caption, originUrl, category, VIEWS_INITIALIZATION, clock);
     }
 
-    public static ReprocessedIssue forSave(final String title, final String imageUrl, final Category category) {
-        return new ReprocessedIssue(null, title, imageUrl, category, VIEWS_INITIALIZATION, Clock.systemDefaultZone());
+    public static ReprocessedIssue forSave(final String title, final String imageUrl, final String caption,
+                                           final String originUrl, final Category category) {
+        return new ReprocessedIssue(null, title, imageUrl, caption, originUrl, category, VIEWS_INITIALIZATION,
+                                    Clock.systemDefaultZone());
     }
 
     @PrePersist
@@ -81,6 +91,10 @@ public class ReprocessedIssue {
     @PreUpdate
     private void preUpdate() {
         updatedAt = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MICROS);
+    }
+
+    public String getTitle() {
+        return title.getValue();
     }
 
     @Override

--- a/src/main/java/com/neupinion/neupinion/issue/domain/ReprocessedIssueTag.java
+++ b/src/main/java/com/neupinion/neupinion/issue/domain/ReprocessedIssueTag.java
@@ -1,0 +1,38 @@
+package com.neupinion.neupinion.issue.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reprocessed_issue_tag")
+@Entity
+public class ReprocessedIssueTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reprocessed_issue_id", nullable = false, updatable = false)
+    private Long reprocessedIssueId;
+
+    @Column(name = "tag", nullable = false)
+    private String tag;
+
+    private ReprocessedIssueTag(final Long id, final Long reprocessedIssueId, final String tag) {
+        this.id = id;
+        this.reprocessedIssueId = reprocessedIssueId;
+        this.tag = tag;
+    }
+
+    public static ReprocessedIssueTag forSave(final Long reprocessedIssueId, final String tag) {
+        return new ReprocessedIssueTag(null, reprocessedIssueId, tag);
+    }
+}

--- a/src/main/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueParagraphRepository.java
+++ b/src/main/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueParagraphRepository.java
@@ -2,6 +2,7 @@ package com.neupinion.neupinion.issue.domain.repository;
 
 import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
 import com.neupinion.neupinion.issue.exception.ParagraphException.ParagraphNotFoundException;
+import java.util.List;
 import java.util.Map;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +15,6 @@ public interface ReprocessedIssueParagraphRepository extends JpaRepository<Repro
                 )
             ));
     }
+
+    List<ReprocessedIssueParagraph> findByReprocessedIssueIdOrderById(final Long reprocessedIssueId);
 }

--- a/src/main/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueTagRepository.java
+++ b/src/main/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueTagRepository.java
@@ -1,0 +1,10 @@
+package com.neupinion.neupinion.issue.domain.repository;
+
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueTag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReprocessedIssueTagRepository extends JpaRepository<ReprocessedIssueTag, Long> {
+
+    List<ReprocessedIssueTag> findByReprocessedIssueId(final Long reprocessedIssueId);
+}

--- a/src/main/java/com/neupinion/neupinion/issue/ui/ReprocessedIssueController.java
+++ b/src/main/java/com/neupinion/neupinion/issue/ui/ReprocessedIssueController.java
@@ -3,12 +3,14 @@ package com.neupinion.neupinion.issue.ui;
 import com.neupinion.neupinion.issue.application.ReprocessedIssueService;
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueCreateRequest;
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueResponse;
+import com.neupinion.neupinion.issue.application.dto.ShortReprocessedIssueResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,9 +34,16 @@ public class ReprocessedIssueController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ReprocessedIssueResponse>> findReprocessedIssueResponses(
+    public ResponseEntity<List<ShortReprocessedIssueResponse>> findReprocessedIssueResponses(
         @RequestParam(value = "date") final String rawDate) {
-        final List<ReprocessedIssueResponse> response = reprocessedIssueService.findReprocessedIssues(rawDate);
+        final List<ShortReprocessedIssueResponse> response = reprocessedIssueService.findReprocessedIssues(rawDate);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ReprocessedIssueResponse> findReprocessedIssueResponse(@PathVariable final Long id) {
+        final ReprocessedIssueResponse response = reprocessedIssueService.findReprocessedIssue(id);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,6 +3,8 @@ create table if not exists reprocessed_issue
     id         bigint auto_increment,
     title      varchar(100) not null,
     image_url  text         not null,
+    caption    varchar(255),
+    origin_url text         not null,
     category   varchar(255) check (category in
                                    ('ENTERTAINMENTS', 'POLITICS', 'ECONOMY', 'SOCIETY', 'WORLD',
                                     'SPORTS')),
@@ -65,21 +67,32 @@ create table if not exists follow_up_issue_views
     id                 bigint auto_increment,
     follow_up_issue_id bigint       not null,
     member_id          bigint       not null,
-    created_at         timestamp(6) not null
+    created_at         timestamp(6) not null,
+    primary key (id)
 );
 
 create table if not exists reprocessed_issue_paragraph
 (
     id                   bigint auto_increment,
-    reprocessed_issue_id bigint       not null,
-    content              text         not null,
-    selectable           boolean      not null
+    reprocessed_issue_id bigint  not null,
+    content              text    not null,
+    selectable           boolean not null,
+    primary key (id)
 );
 
 create table if not exists follow_up_issue_paragraph
 (
     id                 bigint auto_increment,
-    follow_up_issue_id bigint       not null,
-    content            text         not null,
-    selectable         boolean      not null
+    follow_up_issue_id bigint  not null,
+    content            text    not null,
+    selectable         boolean not null,
+    primary key (id)
+);
+
+create table if not exists reprocessed_issue_tag
+(
+    id                   bigint auto_increment,
+    reprocessed_issue_id bigint       not null,
+    tag                  varchar(100) not null,
+    primary key (id)
 );

--- a/src/test/java/com/neupinion/neupinion/issue/application/FollowUpIssueServiceTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/application/FollowUpIssueServiceTest.java
@@ -62,7 +62,7 @@ class FollowUpIssueServiceTest extends JpaRepositoryTest {
     void 후속_이슈를_생성한다() {
         // given
         final ReprocessedIssue savedReprocessedIssue = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", Category.ECONOMY));
+            ReprocessedIssue.forSave("제목1", "image", "이미지", "originUrl", Category.ECONOMY));
         final FollowUpIssueCreateRequest request = FollowUpIssueCreateRequest.of("후속 이슈 제목",
                                                                                  Category.ECONOMY.name(),
                                                                                  "https://neupinion.com/image.jpg",
@@ -107,7 +107,7 @@ class FollowUpIssueServiceTest extends JpaRepositoryTest {
         final long memberId = 1L;
 
         final ReprocessedIssue savedReprocessedIssue = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", category));
+            ReprocessedIssue.forSave("제목1", "image", "이미지", "originUrl", Category.ECONOMY));
 
         final Clock clock = Clock.fixed(Instant.parse("2024-02-06T10:00:00Z"), Clock.systemDefaultZone().getZone());
         final FollowUpIssue savedFollowUpIssue1 = followUpIssueRepository.save(
@@ -123,8 +123,10 @@ class FollowUpIssueServiceTest extends JpaRepositoryTest {
             FollowUpIssue.forSave("후속 이슈 제목4", "https://neupinion.com/image.jpg", otherCategory,
                                   FollowUpIssueTag.INTERVIEW, savedReprocessedIssue.getId(), clock));
 
-        followUpIssueOpinionRepository.save(FollowUpIssueOpinion.forSave(1L, savedFollowUpIssue1.getId(), memberId, "내용"));
-        followUpIssueOpinionRepository.save(FollowUpIssueOpinion.forSave(1L, savedFollowUpIssue2.getId(), memberId, "내용"));
+        followUpIssueOpinionRepository.save(
+            FollowUpIssueOpinion.forSave(1L, savedFollowUpIssue1.getId(), memberId, "내용"));
+        followUpIssueOpinionRepository.save(
+            FollowUpIssueOpinion.forSave(1L, savedFollowUpIssue2.getId(), memberId, "내용"));
 
         // when
         final var result = followUpIssueService.findFollowUpIssueByCategoryAndDate("20240206", category.name(),
@@ -146,7 +148,7 @@ class FollowUpIssueServiceTest extends JpaRepositoryTest {
         // given
         final Category category = Category.ECONOMY;
         final ReprocessedIssue savedReprocessedIssue = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", category));
+            ReprocessedIssue.forSave("제목1", "image", "이미지", "originUrl", Category.ECONOMY));
         final FollowUpIssue followUpIssue = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,
                                   FollowUpIssueTag.INTERVIEW, savedReprocessedIssue.getId()));
@@ -166,7 +168,7 @@ class FollowUpIssueServiceTest extends JpaRepositoryTest {
         final Category category = Category.ECONOMY;
 
         final ReprocessedIssue savedReprocessedIssue = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", category));
+            ReprocessedIssue.forSave("제목1", "image", "이미지", "originUrl", Category.ECONOMY));
 
         final FollowUpIssue savedFollowUpIssue1 = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,

--- a/src/test/java/com/neupinion/neupinion/issue/application/ReprocessedIssueServiceTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/application/ReprocessedIssueServiceTest.java
@@ -3,9 +3,14 @@ package com.neupinion.neupinion.issue.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueResponse;
+import com.neupinion.neupinion.issue.application.dto.ShortReprocessedIssueResponse;
 import com.neupinion.neupinion.issue.domain.Category;
 import com.neupinion.neupinion.issue.domain.ReprocessedIssue;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueTag;
+import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueParagraphRepository;
 import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueRepository;
+import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueTagRepository;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -24,11 +29,19 @@ class ReprocessedIssueServiceTest {
     @Autowired
     private ReprocessedIssueRepository reprocessedIssueRepository;
 
+    @Autowired
+    private ReprocessedIssueParagraphRepository reprocessedIssueParagraphRepository;
+
+    @Autowired
+    private ReprocessedIssueTagRepository reprocessedIssueTagRepository;
+
     private ReprocessedIssueService reprocessedIssueService;
 
     @BeforeEach
     void setUp() {
-        reprocessedIssueService = new ReprocessedIssueService(reprocessedIssueRepository);
+        reprocessedIssueService = new ReprocessedIssueService(reprocessedIssueRepository,
+                                                              reprocessedIssueParagraphRepository,
+                                                              reprocessedIssueTagRepository);
     }
 
     @Test
@@ -37,24 +50,59 @@ class ReprocessedIssueServiceTest {
         final Clock clock = Clock.fixed(Instant.parse("2024-02-04T10:00:00Z"), ZoneId.of("Asia/Seoul"));
         final Clock clock2 = Clock.fixed(Instant.parse("2024-02-05T10:00:00Z"), ZoneId.of("Asia/Seoul"));
         final ReprocessedIssue issue1 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", Category.ECONOMY, clock2));
+            ReprocessedIssue.forSave("제목1", "image", "이미지 캡션", "originUrl", Category.ECONOMY, clock2));
         final ReprocessedIssue issue2 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목2", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목2", "image", "이미지 캡션", "originUrl", Category.ECONOMY, clock));
         final ReprocessedIssue issue3 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목3", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목3", "image", "이미지 캡션", "originUrl", Category.ECONOMY, clock));
         final ReprocessedIssue issue4 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목4", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목4", "image", "이미지 캡션", "originUrl", Category.ECONOMY, clock));
         final ReprocessedIssue issue5 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목5", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목5", "image", "이미지 캡션", "originUrl", Category.ECONOMY, clock));
 
         // when
-        List<ReprocessedIssueResponse> response = reprocessedIssueService.findReprocessedIssues("20240204");
+        final List<ShortReprocessedIssueResponse> issues = reprocessedIssueService.findReprocessedIssues("20240204");
 
         // then
         // 5 4 3 2
-        assertThat(response.stream()
-                       .map(ReprocessedIssueResponse::getId)
+        assertThat(issues.stream()
+                       .map(ShortReprocessedIssueResponse::getId)
                        .toList())
             .containsExactlyInAnyOrder(issue5.getId(), issue4.getId(), issue3.getId(), issue2.getId());
+    }
+
+    @Test
+    void 재가공_이슈의_내용을_조회한다() {
+        // given
+        final ReprocessedIssue issue = reprocessedIssueRepository.save(
+            ReprocessedIssue.forSave("제목1", "image", "이미지 캡션", "originUrl", Category.ECONOMY));
+        final ReprocessedIssueParagraph paragraph1 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용1", true, issue.getId()));
+        final ReprocessedIssueParagraph paragraph2 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용2", true, issue.getId()));
+        final ReprocessedIssueParagraph paragraph3 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용3", true, issue.getId()));
+        final ReprocessedIssueParagraph paragraph4 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용4", true, issue.getId()));
+        final ReprocessedIssueParagraph paragraph5 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용5", true, issue.getId()));
+
+        final ReprocessedIssueTag tag1 = reprocessedIssueTagRepository.save(
+            ReprocessedIssueTag.forSave(issue.getId(), "태그1"));
+        final ReprocessedIssueTag tag2 = reprocessedIssueTagRepository.save(
+            ReprocessedIssueTag.forSave(issue.getId(), "태그2"));
+        final ReprocessedIssueTag tag3 = reprocessedIssueTagRepository.save(
+            ReprocessedIssueTag.forSave(issue.getId(), "태그3"));
+
+        // when
+        final ReprocessedIssueResponse response = reprocessedIssueService.findReprocessedIssue(issue.getId());
+
+        // then
+        assertThat(response.getContent())
+            .usingRecursiveComparison()
+            .comparingOnlyFields("id")
+            .isEqualTo(List.of(paragraph1, paragraph2, paragraph3, paragraph4, paragraph5));
+        assertThat(response.getTags())
+            .containsExactlyInAnyOrder(tag1.getTag(), tag2.getTag(), tag3.getTag());
     }
 }

--- a/src/test/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueParagraphRepositoryTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueParagraphRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.neupinion.neupinion.issue.domain.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
+import com.neupinion.neupinion.utils.JpaRepositoryTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("NonAsciiCharacters")
+class ReprocessedIssueParagraphRepositoryTest extends JpaRepositoryTest {
+
+    @Autowired
+    private ReprocessedIssueParagraphRepository reprocessedIssueParagraphRepository;
+
+    @Test
+    void 재가공_이슈의_ID로_문단을_ID_오름차순으로_조회한다() {
+        // given
+        final long reprocessedIssueId = 1L;
+        final ReprocessedIssueParagraph paragraph1 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용", true, reprocessedIssueId));
+        final ReprocessedIssueParagraph paragraph2 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용", true, reprocessedIssueId));
+        final ReprocessedIssueParagraph paragraph3 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용", true, reprocessedIssueId));
+        final ReprocessedIssueParagraph paragraph4 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용", true, reprocessedIssueId));
+        final ReprocessedIssueParagraph paragraph5 = reprocessedIssueParagraphRepository.save(
+            ReprocessedIssueParagraph.forSave("내용", true, reprocessedIssueId));
+
+        saveAndClearEntityManager();
+
+        // when
+        final List<ReprocessedIssueParagraph> paragraphs = reprocessedIssueParagraphRepository.findByReprocessedIssueIdOrderById(
+            reprocessedIssueId);
+
+        // then
+        assertThat(paragraphs).usingRecursiveComparison()
+            .comparingOnlyFields("id")
+            .isEqualTo(List.of(paragraph1, paragraph2, paragraph3, paragraph4, paragraph5));
+    }
+}

--- a/src/test/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueRepositoryTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/domain/repository/ReprocessedIssueRepositoryTest.java
@@ -33,11 +33,11 @@ class ReprocessedIssueRepositoryTest extends JpaRepositoryTest {
         final Clock clock = Clock.fixed(Instant.parse("2024-02-04T10:00:00Z"), ZoneId.of("Asia/Seoul"));
 
         final ReprocessedIssue issue1 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목1", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목1", "image", "이미지", "originUrl", Category.ECONOMY, clock));
         final ReprocessedIssue issue2 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목2", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목2", "image", "이미지", "originUrl", Category.ECONOMY, clock));
         final ReprocessedIssue issue3 = reprocessedIssueRepository.save(
-            ReprocessedIssue.forSave("제목3", "image", Category.ECONOMY, clock));
+            ReprocessedIssue.forSave("제목3", "image", "이미지", "originUrl", Category.ECONOMY, clock));
         System.out.println("time" + LocalDateTime.now(clock));
 
         reprocessedIssueOpinionRepository.save(ReprocessedIssueOpinion.forSave(1L, issue1.getId(), 1L, "댓글1"));

--- a/src/test/java/com/neupinion/neupinion/issue/ui/FollowUpIssueControllerTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/ui/FollowUpIssueControllerTest.java
@@ -48,7 +48,7 @@ class FollowUpIssueControllerTest extends RestAssuredSpringBootTest {
     void createFollowUpIssue() {
         // given
         final Long reprocessedIssueId = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", Category.WORLD.name()));
+            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", "이미지", "originurl", Category.WORLD.name()));
         final FollowUpIssueCreateRequest request = FollowUpIssueCreateRequest.of("후속 이슈 제목", Category.WORLD.name(),
                                                                                  "https://neupinion.com/image.jpg",
                                                                                  FollowUpIssueTag.OFFICIAL_POSITION.name(),
@@ -97,7 +97,7 @@ class FollowUpIssueControllerTest extends RestAssuredSpringBootTest {
         final Clock clock = Clock.fixed(Instant.parse("2024-02-06T00:00:00Z"), ZoneId.systemDefault());
 
         final Long reprocessedIssueId = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", "이미지", "originurl", Category.WORLD.name()));
         final FollowUpIssue followUpIssue1 = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,
                                   FollowUpIssueTag.OFFICIAL_POSITION, reprocessedIssueId, clock));
@@ -138,9 +138,9 @@ class FollowUpIssueControllerTest extends RestAssuredSpringBootTest {
         final Clock clock = Clock.fixed(Instant.parse("2024-02-06T00:00:00Z"), ZoneId.systemDefault());
 
         final Long reprocessedIssueId = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", "이미지", "originurl", Category.WORLD.name()));
         final Long otherReprocessedIssue = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("다른 재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("다른 재가공 이슈 제목", "image", "이미지", "originurl", Category.WORLD.name()));
 
         final FollowUpIssue followUpIssue1 = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,
@@ -183,7 +183,7 @@ class FollowUpIssueControllerTest extends RestAssuredSpringBootTest {
         // given
         final Category category = Category.WORLD;
         final Long reprocessedIssueId = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", "이미지", "originurl", Category.WORLD.name()));
         final FollowUpIssue followUpIssue = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,
                                   FollowUpIssueTag.OFFICIAL_POSITION, reprocessedIssueId));
@@ -216,9 +216,9 @@ class FollowUpIssueControllerTest extends RestAssuredSpringBootTest {
         final Long memberId = 1L;
 
         final Long reprocessedIssueId = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("재가공 이슈 제목", "image", "이미지", "originurl", category.name()));
         final Long otherReprocessedIssue = reprocessedIssueService.createReprocessedIssue(
-            ReprocessedIssueCreateRequest.of("다른 재가공 이슈 제목", "image", category.name()));
+            ReprocessedIssueCreateRequest.of("다른 재가공 이슈 제목", "image", "이미지", "originurl", category.name()));
 
         final FollowUpIssue followUpIssue1 = followUpIssueRepository.save(
             FollowUpIssue.forSave("후속 이슈 제목1", "https://neupinion.com/image.jpg", category,

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -3,6 +3,8 @@ create table if not exists reprocessed_issue
     id         bigint auto_increment,
     title      varchar(100) not null,
     image_url  text         not null,
+    caption    varchar(255),
+    origin_url text         not null,
     category   varchar(255) check (category in
                                    ('ENTERTAINMENTS', 'POLITICS', 'ECONOMY', 'SOCIETY', 'WORLD',
                                     'SPORTS')),
@@ -65,21 +67,32 @@ create table if not exists follow_up_issue_views
     id                 bigint auto_increment,
     follow_up_issue_id bigint       not null,
     member_id          bigint       not null,
-    created_at         timestamp(6) not null
+    created_at         timestamp(6) not null,
+    primary key (id)
 );
 
 create table if not exists reprocessed_issue_paragraph
 (
     id                   bigint auto_increment,
-    reprocessed_issue_id bigint       not null,
-    content              text         not null,
-    selectable           boolean      not null
+    reprocessed_issue_id bigint  not null,
+    content              text    not null,
+    selectable           boolean not null,
+    primary key (id)
 );
 
 create table if not exists follow_up_issue_paragraph
 (
     id                 bigint auto_increment,
-    follow_up_issue_id bigint       not null,
-    content            text         not null,
-    selectable         boolean      not null
+    follow_up_issue_id bigint  not null,
+    content            text    not null,
+    selectable         boolean not null,
+    primary key (id)
+);
+
+create table if not exists reprocessed_issue_tag
+(
+    id                   bigint auto_increment,
+    reprocessed_issue_id bigint       not null,
+    tag                  varchar(100) not null,
+    primary key (id)
 );


### PR DESCRIPTION
## 구현한 내용

재가공 이슈의 상세 페이지 API를 구현한다.

## 참고 사항

- 재가공 이슈의 Tag 엔티티 추가
- 이전 커밋에서 빠진 primary key 추가

closes #11