### PR TITLE
Feat/#37 재가공 이슈의 후속 이슈를 발행 일자 순서대로 3개 조회하는 API 구현

### DIFF
--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/FollowUpIssuesByReprocessedIssueResponse.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/FollowUpIssuesByReprocessedIssueResponse.java
@@ -1,0 +1,37 @@
+package com.neupinion.neupinion.issue.application.dto;
+
+import com.neupinion.neupinion.issue.domain.FollowUpIssue;
+import com.neupinion.neupinion.issue.domain.ReprocessedIssue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "재가공 이슈의 후속 이슈 정보 응답")
+@AllArgsConstructor
+@Getter
+public class FollowUpIssuesByReprocessedIssueResponse {
+
+    @Schema(description = "재가공 이슈 제목", example = "재가공 이슈 제목")
+    private final String title;
+
+    @Schema(description = "발행 일자 오름차순으로 정렬된 후속 이슈 3개")
+    private final List<ShortFollowUpIssueResponse> followUpIssues;
+
+    @Schema(description = "통합 투표를 볼 수 있는지 여부", example = "true")
+    private final boolean isIntegratedVotePossible;
+
+    public static FollowUpIssuesByReprocessedIssueResponse of(final ReprocessedIssue reprocessedIssue,
+                                                              final List<FollowUpIssue> followUpIssues,
+                                                              final boolean isIntegratedVotePossible) {
+        final List<ShortFollowUpIssueResponse> followUpIssueResponses = followUpIssues.stream()
+            .map(ShortFollowUpIssueResponse::from)
+            .toList();
+
+        return new FollowUpIssuesByReprocessedIssueResponse(reprocessedIssue.getTitle(), followUpIssueResponses, isIntegratedVotePossible);
+    }
+
+    public boolean getIsIntegratedVotePossible() {
+        return isIntegratedVotePossible;
+    }
+}

--- a/src/main/java/com/neupinion/neupinion/issue/application/dto/ShortFollowUpIssueResponse.java
+++ b/src/main/java/com/neupinion/neupinion/issue/application/dto/ShortFollowUpIssueResponse.java
@@ -1,0 +1,34 @@
+package com.neupinion.neupinion.issue.application.dto;
+
+import com.neupinion.neupinion.issue.domain.FollowUpIssue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(description = "해당 재가공 이슈의 후속 이슈 응답")
+@Getter
+@AllArgsConstructor
+public class ShortFollowUpIssueResponse {
+
+    @Schema(description = "후속 이슈 ID", example = "1")
+    private final Long id;
+
+    @Schema(description = "후속 이슈 제목", example = "후속 이슈 제목")
+    private final String title;
+
+    @Schema(description = "후속 이슈 카테고리", example = "국제")
+    private final String category;
+
+    @Schema(description = "후속 이슈 생성 날짜", example = "2024-04-25T14:00:00")
+    private final LocalDateTime createdAt;
+
+    public static ShortFollowUpIssueResponse from(final FollowUpIssue followUpIssue) {
+        return new ShortFollowUpIssueResponse(
+            followUpIssue.getId(),
+            followUpIssue.getTitle().getValue(),
+            followUpIssue.getCategory().getValue(),
+            followUpIssue.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/neupinion/neupinion/issue/domain/repository/FollowUpIssueRepository.java
+++ b/src/main/java/com/neupinion/neupinion/issue/domain/repository/FollowUpIssueRepository.java
@@ -5,6 +5,7 @@ import com.neupinion.neupinion.issue.domain.FollowUpIssue;
 import com.neupinion.neupinion.issue.domain.repository.dto.FollowUpIssueWithReprocessedIssueTitle;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -24,6 +25,9 @@ public interface FollowUpIssueRepository extends JpaRepository<FollowUpIssue, Lo
         + "WHERE t.memberId = :memberId AND t.reprocessedIssueId = f.reprocessedIssueId "
         + "ORDER BY f.createdAt DESC "
         + "LIMIT 3"
-        )
+    )
     List<FollowUpIssue> findFollowUpIssuesOfVotedReprocessedIssueSortByCreatedAt(final Long memberId);
+
+    List<FollowUpIssue> findByReprocessedIssueIdOrderByCreatedAtDesc(final Long reprocessedIssueId,
+                                                                     final Pageable pageable);
 }

--- a/src/main/java/com/neupinion/neupinion/issue/ui/ReprocessedIssueController.java
+++ b/src/main/java/com/neupinion/neupinion/issue/ui/ReprocessedIssueController.java
@@ -1,6 +1,7 @@
 package com.neupinion.neupinion.issue.ui;
 
 import com.neupinion.neupinion.issue.application.ReprocessedIssueService;
+import com.neupinion.neupinion.issue.application.dto.FollowUpIssuesByReprocessedIssueResponse;
 import com.neupinion.neupinion.issue.application.dto.RecentReprocessedIssueByCategoryResponse;
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueCreateRequest;
 import com.neupinion.neupinion.issue.application.dto.ReprocessedIssueResponse;
@@ -77,6 +78,13 @@ public class ReprocessedIssueController {
     @GetMapping("/{id}/trust-vote")
     public ResponseEntity<ReprocessedIssueVoteResultResponse> getVoteResult(@PathVariable final Long id) {
         final ReprocessedIssueVoteResultResponse response = reprocessedIssueService.getVoteResult(id);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}/follow-up-issue")
+    public ResponseEntity<FollowUpIssuesByReprocessedIssueResponse> getFollowUpIssues(@PathVariable final Long id) {
+        FollowUpIssuesByReprocessedIssueResponse response = reprocessedIssueService.getFollowUpIssues(id);
 
         return ResponseEntity.ok(response);
     }

--- a/src/test/java/com/neupinion/neupinion/issue/application/ReprocessedIssueServiceTest.java
+++ b/src/test/java/com/neupinion/neupinion/issue/application/ReprocessedIssueServiceTest.java
@@ -15,6 +15,7 @@ import com.neupinion.neupinion.issue.domain.ReprocessedIssueParagraph;
 import com.neupinion.neupinion.issue.domain.ReprocessedIssueTag;
 import com.neupinion.neupinion.issue.domain.ReprocessedIssueTrustVote;
 import com.neupinion.neupinion.issue.domain.VoteStatus;
+import com.neupinion.neupinion.issue.domain.repository.FollowUpIssueRepository;
 import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueParagraphRepository;
 import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueRepository;
 import com.neupinion.neupinion.issue.domain.repository.ReprocessedIssueTagRepository;
@@ -46,6 +47,9 @@ class ReprocessedIssueServiceTest extends JpaRepositoryTest {
     @Autowired
     private ReprocessedIssueTrustVoteRepository reprocessedIssueTrustVoteRepository;
 
+    @Autowired
+    private FollowUpIssueRepository followUpIssueRepository;
+
     private ReprocessedIssueService reprocessedIssueService;
 
     @BeforeEach
@@ -54,7 +58,8 @@ class ReprocessedIssueServiceTest extends JpaRepositoryTest {
                                                               reprocessedIssueParagraphRepository,
                                                               reprocessedIssueTagRepository,
                                                               reprocessedIssueBookmarkRepository,
-                                                              reprocessedIssueTrustVoteRepository);
+                                                              reprocessedIssueTrustVoteRepository,
+                                                              followUpIssueRepository);
     }
 
     @Test


### PR DESCRIPTION
closes #37